### PR TITLE
Add API endpoint with 24 hour caching for the existing handler

### DIFF
--- a/reward-monitor-lambda-app/app.ts
+++ b/reward-monitor-lambda-app/app.ts
@@ -1,4 +1,4 @@
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { APIGatewayEvent, APIGatewayProxyResult, Context, EventBridgeEvent } from 'aws-lambda';
 
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
@@ -7,15 +7,24 @@ const TABLE_NAME = process.env.TABLE_NAME;
 
 /**
  *
- * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
- * @param {Object} event - API Gateway Lambda Proxy Input Format
+ * @param {Object} event - API Gateway Lambda Proxy Input Format or EventBridge Event
  *
  * Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
  * @returns {Object} object - API Gateway Lambda Proxy Output Format
  *
  */
 
-export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+export const lambdaHandler = async (
+    event: APIGatewayEvent | EventBridgeEvent<string, any>,
+    context: Context,
+): Promise<APIGatewayProxyResult> => {
+    if ('source' in event) {
+        console.log('EventBridge event received');
+        console.log(JSON.stringify(event, null, 2));
+    } else {
+        console.log('API Gateway event received');
+        console.log(JSON.stringify(event, null, 2));
+    }
     // Create client objects
     const ddbClient = new DynamoDBClient({});
     const ddbDocClient = DynamoDBDocumentClient.from(ddbClient);

--- a/template.yaml
+++ b/template.yaml
@@ -1,10 +1,10 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
   reward-monitor-app
 
   For running simple job every 24 hours and trigger alerting if needed
-  
+
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
@@ -41,16 +41,34 @@ Resources:
           Type: Schedule
           Properties:
             Schedule: cron(0 0 ? * * *)
+        GetRecentlySavedJson:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RewardMonitorApi
+            Path: /check
+            Method: get
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
         Minify: true
         Target: "es2020"
         Sourcemap: true
-        EntryPoints: 
-        - app.ts
+        EntryPoints:
+          - app.ts
         External:
-        - "@aws-sdk"
+          - "@aws-sdk"
+
+  RewardMonitorApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      CacheClusterEnabled: true
+      CacheClusterSize: "0.5"
+      MethodSettings:
+        - CachingEnabled: true
+          CacheTtlInSeconds: 86400 # This endpoint caches results for 24 hours
+          HttpMethod: "GET" # Only accept GET requests
+          ResourcePath: "/*" # All paths
 
 Outputs:
   # Outputs can be checked under the CloudFormation stack page
@@ -60,3 +78,6 @@ Outputs:
   RewardMonitorFunctionIamRole:
     Description: "Implicit IAM Role created for Reward Monitor Lambda function"
     Value: !GetAtt RewardMonitorFunctionRole.Arn
+  ProdDataEndpoint:
+    Description: "API Prod stage endpoint"
+    Value: !Sub "https://${RewardMonitorApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"


### PR DESCRIPTION
Adds a new resource, API endpoint, and create connection to the lambda function with `/check` path

Use same lambda handler for both events, CloudWatch and API gateway