### PR TITLE
Change runway alert limit from 1 week to 3 days

### DIFF
--- a/reward-monitor-lambda-app/src/utils/time.ts
+++ b/reward-monitor-lambda-app/src/utils/time.ts
@@ -6,3 +6,9 @@ export const getUTCDayTimestamp = (): number => {
     const now = new Date();
     return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
 };
+
+export enum TimeInSeconds {
+    Day = 86400,
+    Week = 604800,
+    Month = 2592000,
+}


### PR DESCRIPTION
In order to reduce redunadant alerts and pings on discord, change the trigger point from 1 week of runway to 3 days of runway.